### PR TITLE
Use LibVLC via WebChimera.js instead of VLC through its HTTP API

### DIFF
--- a/app.iced
+++ b/app.iced
@@ -214,7 +214,7 @@ ts3clientService.on "started", (ts3proc) =>
 				ts3query.sendtextmessage args.targetmode, invoker.id, "Cleared the playlist."
 			when "list", "playlist"
 				message = "Currently these tracks are in the playlist:\n"
-				for i in [ 0 .. vlc.playlist.items.count ]
+				for i in [ 1 .. vlc.playlist.items.count ]
 					if vlc.playlist.currentItem == i
 						message += "[COLOR=green][B]"
 					info = vlcMediaInfo[vlc.playlist.items[i].mrl]

--- a/app.iced
+++ b/app.iced
@@ -64,15 +64,15 @@ ts3clientService.on "started", (ts3proc) =>
 	ts3query = ts3clientService.query
 
 	# VLC event handling
-	vlc.onPlaying () =>
+	vlc.onPlaying = () =>
 		info = vlcMediaInfo[vlc.playlist.items[vlc.playlist.currentItem].mrl]
 		ts3query.sendtextmessage 2, 0, "Now playing [URL=#{info.originalUrl}]#{info.title}[/URL]."
-	vlc.onPaused () => ts3query.sendtextmessage 2, 0, "Paused."
-	vlc.onForward () => ts3query.sendtextmessage 2, 0, "Fast-forwarding..."
-	vlc.onBackward () => ts3query.sendtextmessage 2, 0, "Rewinding..."
-	vlc.onEncounteredError () => log.error "VLC has encountered an error! You will need to restart the bot.", arguments
-	vlc.onEndReached () => ts3query.sendtextmessage 2, 0, "End of playlist reached."
-	vlc.onStopped () => ts3query.sendtextmessage 2, 0, "Stopped."
+	vlc.onPaused = () => ts3query.sendtextmessage 2, 0, "Paused."
+	vlc.onForward = () => ts3query.sendtextmessage 2, 0, "Fast-forwarding..."
+	vlc.onBackward = () => ts3query.sendtextmessage 2, 0, "Rewinding..."
+	vlc.onEncounteredError = () => log.error "VLC has encountered an error! You will need to restart the bot.", arguments
+	vlc.onEndReached = () => ts3query.sendtextmessage 2, 0, "End of playlist reached."
+	vlc.onStopped = () => ts3query.sendtextmessage 2, 0, "Stopped."
 
 	ts3query.currentScHandlerID = 1
 	ts3query.mydata = {}

--- a/app.iced
+++ b/app.iced
@@ -205,6 +205,24 @@ ts3clientService.on "started", (ts3proc) =>
 
 				# play it in VLC
 				vlc.play info.url
+			when "loop"
+				inputBB = paramline
+				input = null
+				switch (removeBB paramline).toLowerCase().trim()
+					when ""
+						# just show current mode
+						ts3query.sendtextmessage args.targetmode, invoker.id, "Playlist looping is #{if vlc.playlist.mode == vlc.playlist.Loop then "on" else "off"}."
+					when "on"
+						# enable looping
+						vlc.playlist.mode = vlc.playlist.Loop
+						ts3query.sendtextmessage args.targetmode, invoker.id, "Playlist looping is now on."
+					when "off"
+						# disable looping
+						vlc.playlist.mode = vlc.playlist.Normal
+						ts3query.sendtextmessage args.targetmode, invoker.id, "Playlist looping is now off."
+					else
+						ts3query.sendtextmessage args.targetmode, invoker.id, "[B]#{name} on|off[/B] - Turns playlist looping on or off"
+						return
 			when "next"
 				vlc.playlist.next()
 			when "prev", "previous"

--- a/app.iced
+++ b/app.iced
@@ -233,19 +233,6 @@ ts3clientService.on "started", (ts3proc) =>
 			when "empty", "clear"
 				vlc.playlist.clear()
 				ts3query.sendtextmessage args.targetmode, invoker.id, "Cleared the playlist."
-			###
-			when "list", "playlist"
-				message = "Currently there are #{vlc.playlist.items.count} tracks are in the playlist"
-				message += if vlc.playlist.items.count > 0 then ":\n" else "."
-				for i in [ 0 ... vlc.playlist.items.count ]
-					if vlc.playlist.currentItem == i
-						message += "[COLOR=green][B]"
-					info = vlcMediaInfo[vlc.playlist.items[i].mrl]
-					message += "#{i + 1}. [URL=#{info.originalUrl}]#{info.title}[/URL]"
-					if vlc.playlist.currentItem == i
-						message += "[/B][/COLOR]"
-				ts3query.sendtextmessage args.targetmode, invoker.id, message
-			###
 			when "enqueue", "add", "append"
 				inputBB = paramline.trim()
 				input = (removeBB paramline).trim()

--- a/app.iced
+++ b/app.iced
@@ -227,11 +227,17 @@ ts3clientService.on "started", (ts3proc) =>
 						ts3query.sendtextmessage args.targetmode, invoker.id, "[B]#{name} on|off[/B] - Turns playlist looping on or off"
 						return
 			when "next"
+				if vlc.playlist.items.count == 0
+					ts3query.sendtextmessage args.targetmode, invoker.id, "The playlist is empty."
+					return
 				if vlc.playlist.mode != vlc.playlist.Loop and vlc.playlist.currentItem == vlc.playlist.items.count - 1
 					ts3query.sendtextmessage args.targetmode, invoker.id, "Can't jump to next playlist item, this is the last one!"
 					return
 				vlc.playlist.next()
 			when "prev", "previous"
+				if vlc.playlist.items.count == 0
+					ts3query.sendtextmessage args.targetmode, invoker.id, "The playlist is empty."
+					return
 				if vlc.playlist.mode != vlc.playlist.Loop and vlc.playlist.currentItem <= 0
 					ts3query.sendtextmessage args.targetmode, invoker.id, "Can't jump to previous playlist item, this is the first one!"
 					return

--- a/app.iced
+++ b/app.iced
@@ -207,6 +207,8 @@ ts3clientService.on "started", (ts3proc) =>
 				vlc.play info.url
 			when "next"
 				vlc.playlist.next()
+			when "prev", "previous"
+				vlc.playlist.prev()
 			when "enqueue", "add", "append"
 				inputBB = paramline.trim()
 				input = (removeBB paramline).trim()

--- a/app.iced
+++ b/app.iced
@@ -205,6 +205,9 @@ ts3clientService.on "started", (ts3proc) =>
 
 				# play it in VLC
 				vlc.play info.url
+			when "stop-after"
+				vlc.playlist.mode = vlc.playlist.Single
+				ts3query.sendtextmessage args.targetmode, invoker.id, "Playback will stop after the current playlist item."
 			when "loop"
 				inputBB = paramline
 				input = null

--- a/app.iced
+++ b/app.iced
@@ -232,7 +232,7 @@ ts3clientService.on "started", (ts3proc) =>
 					return
 				vlc.playlist.next()
 			when "prev", "previous"
-				if vlc.playlist.mode != vlc.playlist.Loop and vlc.playlist.currentItem == 0
+				if vlc.playlist.mode != vlc.playlist.Loop and vlc.playlist.currentItem <= 0
 					ts3query.sendtextmessage args.targetmode, invoker.id, "Can't jump to previous playlist item, this is the first one!"
 					return
 				vlc.playlist.prev()

--- a/app.iced
+++ b/app.iced
@@ -255,7 +255,7 @@ ts3clientService.on "started", (ts3proc) =>
 			when "vol"
 				vol = parseInt paramline
 
-				if paramline.trim().length <= 0 or vol > 200 or vol < 0
+				if paramline.trim().length <= 0 or vol == NaN or vol > 200 or vol < 0
 					ts3query.sendtextmessage args.targetmode, invoker.id, "[B]vol <number>[/B] - takes a number between 0 (0%) and 200 (200%) to set the volume. 100% is 100. Defaults to 50 (50%) on startup."
 					return
 

--- a/app.iced
+++ b/app.iced
@@ -227,8 +227,14 @@ ts3clientService.on "started", (ts3proc) =>
 						ts3query.sendtextmessage args.targetmode, invoker.id, "[B]#{name} on|off[/B] - Turns playlist looping on or off"
 						return
 			when "next"
+				if vlc.playlist.mode != vlc.playlist.Loop and vlc.playlist.currentItem == vlc.playlist.items.count - 1
+					ts3query.sendtextmessage args.targetmode, invoker.id, "Can't jump to next playlist item, this is the last one!"
+					return
 				vlc.playlist.next()
 			when "prev", "previous"
+				if vlc.playlist.mode != vlc.playlist.Loop and vlc.playlist.currentItem == 0
+					ts3query.sendtextmessage args.targetmode, invoker.id, "Can't jump to previous playlist item, this is the first one!"
+					return
 				vlc.playlist.prev()
 			when "empty", "clear"
 				vlc.playlist.clear()

--- a/app.iced
+++ b/app.iced
@@ -214,7 +214,7 @@ ts3clientService.on "started", (ts3proc) =>
 				ts3query.sendtextmessage args.targetmode, invoker.id, "Cleared the playlist."
 			when "list", "playlist"
 				message = "Currently these tracks are in the playlist:\n"
-				for i in [ 1 .. vlc.playlist.items.count ]
+				for i in [ 0 ... vlc.playlist.items.count ]
 					if vlc.playlist.currentItem == i
 						message += "[COLOR=green][B]"
 					info = vlcMediaInfo[vlc.playlist.items[i].mrl]

--- a/app.iced
+++ b/app.iced
@@ -212,6 +212,16 @@ ts3clientService.on "started", (ts3proc) =>
 			when "empty", "clear"
 				vlc.playlist.clear()
 				ts3query.sendtextmessage args.targetmode, invoker.id, "Cleared the playlist."
+			when "list", "playlist"
+				message = "Currently these tracks are in the playlist:\n"
+				for i in [ 0 .. vlc.playlist.items.count ]
+					if vlc.playlist.currentItem == i
+						message += "[COLOR=green][B]"
+					info = vlcMediaInfo[vlc.playlist.items[i].mrl]
+					message += "#{i + 1}. [URL=#{info.originalUrl}]#{info.title}[/URL]"
+					if vlc.playlist.currentItem == i
+						message += "[/B][/COLOR]"
+				ts3query.sendtextmessage args.targetmode, invoker.id, message
 			when "enqueue", "add", "append"
 				inputBB = paramline.trim()
 				input = (removeBB paramline).trim()

--- a/app.iced
+++ b/app.iced
@@ -213,7 +213,8 @@ ts3clientService.on "started", (ts3proc) =>
 				vlc.playlist.clear()
 				ts3query.sendtextmessage args.targetmode, invoker.id, "Cleared the playlist."
 			when "list", "playlist"
-				message = "Currently these tracks are in the playlist:\n"
+				message = "Currently there are #{vlc.playlist.items.count} tracks are in the playlist"
+				message += if vlc.playlist.items.count > 0 then ":\n" else "."
 				for i in [ 0 ... vlc.playlist.items.count ]
 					if vlc.playlist.currentItem == i
 						message += "[COLOR=green][B]"

--- a/app.iced
+++ b/app.iced
@@ -71,7 +71,6 @@ ts3clientService.on "started", (ts3proc) =>
 	vlc.onForward = () => ts3query.sendtextmessage 2, 0, "Fast-forwarding..."
 	vlc.onBackward = () => ts3query.sendtextmessage 2, 0, "Rewinding..."
 	vlc.onEncounteredError = () => log.error "VLC has encountered an error! You will need to restart the bot.", arguments
-	vlc.onEndReached = () => ts3query.sendtextmessage 2, 0, "End of playlist reached."
 	vlc.onStopped = () => ts3query.sendtextmessage 2, 0, "Stopped."
 
 	ts3query.currentScHandlerID = 1

--- a/app.iced
+++ b/app.iced
@@ -209,6 +209,9 @@ ts3clientService.on "started", (ts3proc) =>
 				vlc.playlist.next()
 			when "prev", "previous"
 				vlc.playlist.prev()
+			when "empty", "clear"
+				vlc.playlist.clear()
+				ts3query.sendtextmessage args.targetmode, invoker.id, "Cleared the playlist."
 			when "enqueue", "add", "append"
 				inputBB = paramline.trim()
 				input = (removeBB paramline).trim()

--- a/app.iced
+++ b/app.iced
@@ -233,6 +233,7 @@ ts3clientService.on "started", (ts3proc) =>
 			when "empty", "clear"
 				vlc.playlist.clear()
 				ts3query.sendtextmessage args.targetmode, invoker.id, "Cleared the playlist."
+			###
 			when "list", "playlist"
 				message = "Currently there are #{vlc.playlist.items.count} tracks are in the playlist"
 				message += if vlc.playlist.items.count > 0 then ":\n" else "."
@@ -244,6 +245,7 @@ ts3clientService.on "started", (ts3proc) =>
 					if vlc.playlist.currentItem == i
 						message += "[/B][/COLOR]"
 				ts3query.sendtextmessage args.targetmode, invoker.id, message
+			###
 			when "enqueue", "add", "append"
 				inputBB = paramline.trim()
 				input = (removeBB paramline).trim()

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sync": "^0.2.5",
     "valid-url": "^1.0.9",
     "vlc-api": "0.0.0",
+    "webchimera.js": "^0.1.38",
     "which": "^1.1.2",
     "winston": "^1.0.1",
     "xvfb": "git://github.com/icedream/node-xvfb.git",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "string.prototype.startswith": "^0.2.0",
     "sync": "^0.2.5",
     "valid-url": "^1.0.9",
-    "vlc-api": "0.0.0",
     "webchimera.js": "^0.1.38",
     "which": "^1.1.2",
     "winston": "^1.0.1",

--- a/ts3query.iced
+++ b/ts3query.iced
@@ -10,9 +10,23 @@ merge = require "merge"
 
 parserLog = getLogger "parser"
 
-escape = (value) => value.toString().replace(///\\///g, "\\\\").replace(/\//g, "\\/").replace(/\|/g, "\\|").replace(///\ ///g, "\\s")
+escape = (value) => value.toString()\
+	.replace(/\\/g, "\\\\")\
+	.replace(/\//g, "\\/")\
+	.replace(/\|/g, "\\|")\
+	.replace(/\n/g, "\\n")\
+	.replace(/\r/g, "\\r")\
+	.replace(/\t/g, "\\t")\
+	.replace(/\ /g, "\\s")
 
-unescape = (value) => value.toString().replace(/\\s/g, " ").replace(/\\\//g, "/").replace(/\\\|/g, "|").replace(/\\\\/g, "\\")
+unescape = (value) => value.toString()\
+	.replace(/\\s/g, " ")\
+	.replace(/\\t/g, "\t")\
+	.replace(/\\r/g, "\r")\
+	.replace(/\\n/g, "\n")\
+	.replace(/\\\|/g, "|")\
+	.replace(/\\\//g, "/")\
+	.replace(/\\\\/g, "\\")
 
 buildCmd = (name, namedArgs, posArgs) =>
 	# TODO: Add support for collected arguments (aka lists)


### PR DESCRIPTION
This closes #17 and #10, finishes two tasks of #2 and actually solves a few additional issues like:
- Not being able to resume playback from a stopped playlist.
- Unclear and buggy definition of volume range.
- Bot just showing "playing next playlist entry" instead of actually showing the title of the next playlist entry.
- Missing "previous" command to go to previous playlist entry.
- Missing "loop" command to loop the playlist. (Now exists in form of "loop on"/"loop off")
- Missing "stop-after" command to stop playback after current track ends.
- A small bug in ts3query.iced that didn't escape line breaks. (Was in use here for "playlist"/"list" commands which got removed in the process.)

Known issues:
- Starting with an empty playlist, adding an entry and then typing "next" will automatically play the first entry. This is not really a bug or even an issue but definitely unexpected behavior that is coming from VLC.
